### PR TITLE
Fix cuDNN v5

### DIFF
--- a/include/caffe/layers/cudnn_ndconv_layer.hpp
+++ b/include/caffe/layers/cudnn_ndconv_layer.hpp
@@ -61,7 +61,8 @@ class CudnnNdConvolutionLayer : public Layer<Dtype> {
   vector<cudnnConvolutionDescriptor_t> conv_descs_;
   int bottom_offset_, top_offset_, weight_offset_, bias_offset_;
   size_t workspaceSizeInBytes;
-  void** workspace;
+  void* workspace_data_;  // underlying storage
+  void** workspace_;  // aliases into workspaceData
   cudnnConvolutionBwdFilterAlgo_t* bwd_filter_algo_;
   cudnnConvolutionBwdDataAlgo_t* bwd_data_algo_;
   size_t* workspace_bwd_filter_sizes_;

--- a/src/caffe/layers/cudnn_ndconv_layer.cpp
+++ b/src/caffe/layers/cudnn_ndconv_layer.cpp
@@ -101,7 +101,7 @@ void CudnnNdConvolutionLayer<Dtype>::LayerSetUp(
   stream_ = new cudaStream_t[this->group_ * CUDNN_STREAMS_PER_GROUP];
   handle_ = new cudnnHandle_t[this->group_ * CUDNN_STREAMS_PER_GROUP];
   workspaceSizeInBytes = 0;
-  workspace = NULL;
+  workspace_data_ = NULL;
 
   for (int g = 0; g < this->group_ * CUDNN_STREAMS_PER_GROUP; g++) {
     CUDA_CHECK(cudaStreamCreate(&stream_[g]));
@@ -124,7 +124,7 @@ void CudnnNdConvolutionLayer<Dtype>::LayerSetUp(
   bwd_data_algo_  = new cudnnConvolutionBwdDataAlgo_t[bottom.size()];
   workspace_bwd_filter_sizes_ = new size_t[bottom.size()];
   workspace_bwd_data_sizes_ = new size_t[bottom.size()];
-  workspace = new void*[this->group_ * CUDNN_STREAMS_PER_GROUP];
+  workspace_ = new void*[this->group_ * CUDNN_STREAMS_PER_GROUP];
   // Create tensor descriptor(s) for data and corresponding convolution(s).
   for (int i = 0; i < bottom.size(); i++) {
     cudnnTensorDescriptor_t bottom_desc;

--- a/src/caffe/layers/cudnn_ndconv_layer.cu
+++ b/src/caffe/layers/cudnn_ndconv_layer.cu
@@ -56,13 +56,13 @@ void CudnnNdConvolutionLayer<Dtype>::Forward_gpu(
       if (workspaceSizeInBytes_temp > workspaceSizeInBytes) {
         workspaceSizeInBytes = workspaceSizeInBytes_temp;
         // free the existing workspace and allocate a new (larger) one
-        cudaFree(this->workspace);
-        cudaError_t err = cudaMalloc(&(this->workspace),
+        cudaFree(this->workspace_data_);
+        cudaError_t err = cudaMalloc(&(this->workspace_data_),
                           workspaceSizeInBytes);
         if (err != cudaSuccess) {
           // force zero memory path
           algo = CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM;
-          workspace = NULL;
+          workspace_data_ = NULL;
           workspaceSizeInBytes = 0;
         }
       }
@@ -73,7 +73,7 @@ void CudnnNdConvolutionLayer<Dtype>::Forward_gpu(
                   bottom_descs_[i], bottom_data + bottom_offset_ * g,
                   filter_desc_, weight + weight_offset_ * g,
                   conv_descs_[i],
-                  algo, workspace, workspaceSizeInBytes,
+                  algo, workspace_data_, workspaceSizeInBytes,
                   cudnn::dataType<Dtype>::zero,
                   top_descs_[i], top_data + top_offset_ * g));
 
@@ -141,7 +141,7 @@ void CudnnNdConvolutionLayer<Dtype>::Backward_gpu(
                     bottom_descs_[i], bottom_data + bottom_offset_ * g,
                     top_descs_[i],    top_diff + top_offset_ * g,
                     conv_descs_[i],
-                    bwd_filter_algo_[i], workspace[1*this->group_ + g],
+                    bwd_filter_algo_[i], workspace_[1*this->group_ + g],
                     workspace_bwd_filter_sizes_[i],
                     cudnn::dataType<Dtype>::one,
                     filter_desc_, weight_diff + weight_offset_ * g));
@@ -178,7 +178,7 @@ void CudnnNdConvolutionLayer<Dtype>::Backward_gpu(
                     filter_desc_, weight + weight_offset_ * g,
                     top_descs_[i], top_diff + top_offset_ * g,
                     conv_descs_[i],
-                    bwd_data_algo_[i], workspace[1*this->group_ + g],
+                    bwd_data_algo_[i], workspace_[1*this->group_ + g],
                     workspace_bwd_data_sizes_[i],
                     cudnn::dataType<Dtype>::zero,
                     bottom_descs_[i], bottom_diff + bottom_offset_ * g));


### PR DESCRIPTION
https://github.com/chuckcho/video-caffe/pull/20 only passed all the unit tests. However, there's an invalid device pointer error in training. It's because the cuDNN workspace pointers are not initialized correctly. With this fix, training using cuDNN v5 converges as fast as using v4.